### PR TITLE
fix: interval error

### DIFF
--- a/src/modules/settings/components/SettingsForm/SettingsForm.tsx
+++ b/src/modules/settings/components/SettingsForm/SettingsForm.tsx
@@ -30,25 +30,26 @@ export const SettingsForm = observer((props: Props) => {
   })
 
   const hoursInterval = watch('hoursInterval')
-  const showHoursIntervalError = useMemo(() => {
+  const checkHoursInterval = () => {
     try {
       return areIntervalsOverlapping(
-        {
-          start: timeToDate(hoursInterval.startWorkingTime),
-          end: timeToDate(hoursInterval.startLunchBreak)
-        },
-        {
-          start: timeToDate(hoursInterval.endLunchBreak),
-          end: timeToDate(hoursInterval.endWorkingTime)
-        }
+          {
+            start: timeToDate(hoursInterval.startWorkingTime),
+            end: timeToDate(hoursInterval.startLunchBreak)
+          },
+          {
+            start: timeToDate(hoursInterval.endLunchBreak),
+            end: timeToDate(hoursInterval.endWorkingTime)
+          }
       )
     } catch (e) {
       return true
     }
-  }, [hoursInterval])
+  }
 
+  const hasHoursIntervalError = checkHoursInterval();
   const values = watch()
-  useAutoSave(values, props.changeSettings)
+  useAutoSave(values, props.changeSettings, hasHoursIntervalError)
 
   const handleChangeTheme = (event: ChangeEvent<HTMLSelectElement>) => {
     const newTheme = event.target.value as Props['theme']
@@ -138,7 +139,7 @@ export const SettingsForm = observer((props: Props) => {
                 <TimeField label={t('settings.to')} inputBgColor={fieldBgColor} {...register('hoursInterval.endLunchBreak')} />
               </Flex>
             </Stack>
-            {showHoursIntervalError && (
+            {hasHoursIntervalError && (
               <Text aria-live="polite" color="red.500" mt={2}>
                 {t('settings.intervals_overlap')}
               </Text>

--- a/src/modules/settings/components/SettingsForm/useAutoSave.ts
+++ b/src/modules/settings/components/SettingsForm/useAutoSave.ts
@@ -3,16 +3,19 @@ import type { SettingsValues } from 'shared/data-access/state/SettingsValues.int
 
 export function useAutoSave(
   values: SettingsValues,
-  changeSettings: (settings: SettingsValues) => void
+  changeSettings: (settings: SettingsValues) => void,
+  hasHoursIntervalError: boolean
 ) {
   const oldStringifiedValue = useRef<string>('')
 
   useEffect(() => {
     const newStringifiedValue = JSON.stringify(values)
 
-    if (oldStringifiedValue.current !== newStringifiedValue) {
-      oldStringifiedValue.current = newStringifiedValue
-      changeSettings(values)
+    if (!hasHoursIntervalError) {
+      if (oldStringifiedValue.current !== newStringifiedValue) {
+        oldStringifiedValue.current = newStringifiedValue
+        changeSettings(values)
+      }
     }
-  }, [changeSettings, values])
+  }, [changeSettings, values, hasHoursIntervalError])
 }


### PR DESCRIPTION
The interval error wasn't changing because  during changes the useMemo() doesn't invoke the callback function (showHoursIntervalError).

Finally, we have optimized the way to change the status of the settings, only when the value is correct. 