### PR TITLE
feat: improve ux on vacation form

### DIFF
--- a/src/modules/vacations/components/VacationForm/VacationForm.test.tsx
+++ b/src/modules/vacations/components/VacationForm/VacationForm.test.tsx
@@ -58,25 +58,61 @@ describe('VacationForm', () => {
     ).toHaveLength(2)
   })
 
-  test('should check that when the start date is after the end date, the end date is set equal to the start date', async () => {
+  test('should check that when the start date is after the end date, the end date is set equal to the start date on start date changes', async () => {
     const { modifyVacationPeriodMock } = setup({
       id: 10,
       startDate: '2020-08-05',
-      endDate: '2020-08-01',
+      endDate: '2020-08-06',
       description: 'Lorem ipsum dolorum...'
     })
 
-    expect(screen.getByLabelText('vacation_form.start_date')).toHaveValue('2020-08-05')
-    expect(screen.getByLabelText('vacation_form.end_date')).toHaveValue('2020-08-05')
-    expect(screen.getByLabelText('vacation_form.description')).toHaveValue('Lorem ipsum dolorum...')
+    userEvent.type(screen.getByLabelText('vacation_form.start_date'), '2020-09-22')
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('vacation_form.start_date')).toHaveValue('2020-09-22')
+      expect(screen.getByLabelText('vacation_form.end_date')).toHaveValue('2020-09-22')
+      expect(screen.getByLabelText('vacation_form.description')).toHaveValue(
+        'Lorem ipsum dolorum...'
+      )
+    })
 
     userEvent.click(screen.getByRole('button', { name: 'actions.save' }))
 
     await waitFor(() => {
       expect(modifyVacationPeriodMock).toHaveBeenCalledWith({
         id: 10,
-        startDate: '2020-08-05',
-        endDate: '2020-08-05',
+        startDate: '2020-09-22',
+        endDate: '2020-09-22',
+        description: 'Lorem ipsum dolorum...'
+      })
+    })
+  })
+
+  test('should check that when the start date is after the end date, the start date is set equal to the end date on end date changes', async () => {
+    const { modifyVacationPeriodMock } = setup({
+      id: 10,
+      startDate: '2020-08-05',
+      endDate: '2020-08-06',
+      description: 'Lorem ipsum dolorum...'
+    })
+
+    userEvent.type(screen.getByLabelText('vacation_form.end_date'), '2020-08-01')
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('vacation_form.start_date')).toHaveValue('2020-08-01')
+      expect(screen.getByLabelText('vacation_form.end_date')).toHaveValue('2020-08-01')
+      expect(screen.getByLabelText('vacation_form.description')).toHaveValue(
+        'Lorem ipsum dolorum...'
+      )
+    })
+
+    userEvent.click(screen.getByRole('button', { name: 'actions.save' }))
+
+    await waitFor(() => {
+      expect(modifyVacationPeriodMock).toHaveBeenCalledWith({
+        id: 10,
+        startDate: '2020-08-01',
+        endDate: '2020-08-01',
         description: 'Lorem ipsum dolorum...'
       })
     })

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -28,7 +28,7 @@
     "activity_hours_overlap": "Hours overlap",
     "date_min_today": "The date must be greater than or equal to today",
     "year_max": "The date must be before",
-    "end_date_greater": "Must be greater than the start date"
+    "end_date_greater": "Must be equal or greater than the start time"
   },
   "login_page": {
     "username_field": "Username",

--- a/src/shared/i18n/es.json
+++ b/src/shared/i18n/es.json
@@ -28,7 +28,7 @@
     "activity_hours_overlap": "Las horas se solapan",
     "date_min_today": "La fecha tiene que ser mayor o igual a hoy",
     "year_max": "La fecha tiene que ser anterior al año",
-    "end_date_greater": "Debe ser mayor que la fecha de inicio"
+    "end_date_greater": "Debe ser igual o mayor que la hora de inicio"
   },
   "login_page": {
     "username_field": "Usuario",


### PR DESCRIPTION
- In the “Vacation Form” if we change the start date after the end date, the end date will be set to the same value as the start date.
- In the "Vacation Form" if we change the end date before the start date, the start date will be set to the same value as the end date.