### PR TITLE
refactor: change use-get-selected-calendar-date implementation

### DIFF
--- a/src/features/binnacle/features/activity/ui/hooks/use-get-selected-calendar-date.test.ts
+++ b/src/features/binnacle/features/activity/ui/hooks/use-get-selected-calendar-date.test.ts
@@ -3,7 +3,7 @@ import { useGetSelectedCalendarDate } from './use-get-selected-calendar-date'
 import chrono from '../../../../../../shared/utils/chrono'
 
 describe('useGetSelectedCalendarDate', () => {
-  const today = new Date('2023-06-02T00:00:00.000Z')
+  const today = new Date(2023, 6, 2)
 
   it('should return the current date', () => {
     chrono.now = jest.fn(() => today)
@@ -12,5 +12,23 @@ describe('useGetSelectedCalendarDate', () => {
     const hook = renderHook(() => useGetSelectedCalendarDate(selectedDate))
 
     expect(hook.result.current).toBe(selectedDate)
+  })
+
+  it('should return the last month of the selected year', () => {
+    const pastDate = new Date(2020, 6, 1) // Jun 1, 2020
+
+    const { result } = renderHook(() => useGetSelectedCalendarDate(pastDate))
+
+    const expectedPastDate = new Date(`${pastDate.getFullYear()}-12-01`)
+    expect(result.current).toEqual(expectedPastDate)
+  })
+
+  it('should return the first month of the selected year', () => {
+    const nextDate = new Date(2024, 7, 2) // July 2, 2024
+
+    const { result } = renderHook(() => useGetSelectedCalendarDate(nextDate))
+
+    const expectedNextDate = new Date(`${nextDate.getFullYear()}-01-01`)
+    expect(result.current).toEqual(expectedNextDate)
   })
 })

--- a/src/features/binnacle/features/activity/ui/hooks/use-get-selected-calendar-date.ts
+++ b/src/features/binnacle/features/activity/ui/hooks/use-get-selected-calendar-date.ts
@@ -2,21 +2,20 @@ import { useEffect, useState } from 'react'
 import chrono from '../../../../../../shared/utils/chrono'
 
 export const useGetSelectedCalendarDate = (selectedDate: Date) => {
-  const [currentDate, setCurrentDate] = useState<Date>(selectedDate)
+  const [date, setDate] = useState<Date>()
 
   useEffect(() => {
-    if (selectedDate.getFullYear() === currentDate.getFullYear()) {
-      return
-    }
-    if (selectedDate.getFullYear() < chrono.now().getFullYear()) {
-      return setCurrentDate(new Date(selectedDate.getFullYear(), 11, 1))
-    }
-    if (selectedDate.getFullYear() > chrono.now().getFullYear()) {
-      return setCurrentDate(new Date(selectedDate.getFullYear(), 0, 1))
-    }
+    const currentDate: Date = chrono.now()
+    const selectedYear = selectedDate.getFullYear()
 
-    setCurrentDate(chrono.now())
+    if (selectedDate.getFullYear() < currentDate.getFullYear()) {
+      setDate(new Date(`${selectedYear}-12-01`))
+    } else if (selectedDate.getFullYear() > currentDate.getFullYear()) {
+      setDate(new Date(`${selectedYear}-01-01`))
+    } else {
+      setDate(currentDate)
+    }
   }, [selectedDate])
 
-  return currentDate
+  return date
 }


### PR DESCRIPTION
Since was very tricky to test the previous implementation, I decided to refactor this custom hook with the purpose of testing and simplicity.