### PR TITLE
feat: disable activities if doesn't have evidence

### DIFF
--- a/src/features/binnacle/features/activity/ui/pending-activities-page.tsx
+++ b/src/features/binnacle/features/activity/ui/pending-activities-page.tsx
@@ -24,6 +24,7 @@ const PendingActivitiesPage = () => {
   const [isLoadingForm, setIsLoadingForm] = useState(false)
   const [tableActivities, setTableActivities] = useState<AdaptedActivity[]>([])
   const isMobile = useIsMobile()
+  const [enableApprove, setEnableApprove] = useState(false)
 
   const { useCase: approveActivityCmd } = useGetUseCase(ApproveActivityCmd)
   const {
@@ -111,6 +112,7 @@ const PendingActivitiesPage = () => {
           onClick={() => {
             setSelectedActivity(activity)
             setShowActivityModal(true)
+            setEnableApprove(!activity.hasEvidences)
           }}
         >
           {t('actions.show')}
@@ -140,7 +142,7 @@ const PendingActivitiesPage = () => {
             colorScheme="brand"
             variant="solid"
             isLoading={isLoadingForm}
-            disabled={false}
+            disabled={enableApprove}
             onClick={() => onApprove()}
           >
             {t('actions.approve')}


### PR DESCRIPTION
Now we are disabling the pending activity approval button when doesn't have evidence.

Screenshot:

<img width="849" alt="image" src="https://github.com/autentia/binnacle-front/assets/20250204/373b0138-1f99-43bc-93eb-feca59a2eaa0">
 